### PR TITLE
Use unique machine name to have more than one

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ docker-machine create -d generic \
   --generic-ssh-key $(vagrant ssh-config | grep IdentityFile | awk '{gsub(/"/, "", $2); print $2}') \
   --generic-ip-address $(vagrant ssh-config | grep HostName | awk '{print $2}') \
   --generic-ssh-port $(vagrant ssh-config | grep Port | awk '{print $2}') \
-  image-builder
+  image-builder-odroid-c1
 ```
 
 Now set the Docker environments to this new docker machine:
 
 ```bash
-eval $(docker-machine env image-builder)
+eval $(docker-machine env image-builder-odroid-c1)
 ```
 
 From here just use `make` to make a new SD-Card image:


### PR DESCRIPTION
To be able to build another image we also need different names for the docker machines.
