### PR TITLE
Install initramfs-tools before installing the kernel

### DIFF
--- a/devicefiles/chroot-script.sh
+++ b/devicefiles/chroot-script.sh
@@ -21,7 +21,7 @@ apt-get install -y parted
 # install odroid kernel
 export DEBIAN_FRONTEND=noninteractive
 mkdir -p /media/boot
-apt-get install -y u-boot-tools
+apt-get install -y u-boot-tools initramfs-tools
 apt-get install -y linux-image-c1
 
 # set device label


### PR DESCRIPTION
Note: This package has to be installed _separately_ before the kernel
package. It contains a postinst script which creates the initrd during
installation of the kernel package. This is a prerequisite for another
kernel postinst script to create the final uInitrd image.

(However, as it turns out, the linux-image-\* package already contains a pre-built uInitrd. So this step is actually  just necessary to make the package installer happy.) 

(fixes #2)
