### PR TITLE
Make bash invocations in shebangs portable

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+set -ex
 # This script should be run only inside of a Docker container
 if [ ! -f /.dockerinit ]; then
   echo "ERROR: script works only in a Docker container!"

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+set -ex
 
 # device specific settings
 HYPRIOT_DEVICE="ODROID C1/C1+"

--- a/builder/files/usr/local/bin/hypriot-resize-rootdisk
+++ b/builder/files/usr/local/bin/hypriot-resize-rootdisk
@@ -1,5 +1,5 @@
-#!/bin/bash -e
-set -x
+#!/bin/bash
+set -ex
 
 # sd card device name for ODROID C1/C1+
 SDCARD_DEVICE="/dev/mmcblk0"


### PR DESCRIPTION
The builder script wouldn't work as expected every time for me. The `-e` wouldn't work at all.

See e.g. this comment for some background for this change:
https://github.com/rbenv/rbenv/issues/20#issuecomment-1791001
