### PR TITLE
Refactor resize rootdisk

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -20,7 +20,7 @@ BUILD_PATH="/build"
 # where to store our base file system
 ROOTFS_TAR="rootfs-armhf.tar.gz"
 ROOTFS_TAR_PATH="$BUILD_RESULT_PATH/$ROOTFS_TAR"
-ROOTFS_TAR_VERSION="v0.5"
+ROOTFS_TAR_VERSION="v0.6"
 
 # size of root and boot partion
 ROOT_PARTITION_SIZE="800M"

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -20,7 +20,7 @@ BUILD_PATH="/build"
 # where to store our base file system
 ROOTFS_TAR="rootfs-armhf.tar.gz"
 ROOTFS_TAR_PATH="$BUILD_RESULT_PATH/$ROOTFS_TAR"
-ROOTFS_TAR_VERSION="v0.6"
+ROOTFS_TAR_VERSION="v0.6.0"
 
 # size of root and boot partion
 ROOT_PARTITION_SIZE="800M"

--- a/builder/files/etc/firstboot.d/10-resize-rootdisk
+++ b/builder/files/etc/firstboot.d/10-resize-rootdisk
@@ -1,6 +1,3 @@
-#!/bin/bash
-set -ex
-
 # sd card device name for ODROID C1/C1+
 SDCARD_DEVICE="/dev/mmcblk0"
 

--- a/builder/files/lib/systemd/system/hypriot-resize-rootdisk.service
+++ b/builder/files/lib/systemd/system/hypriot-resize-rootdisk.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Resize root disk to maximum size
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/hypriot-resize-rootdisk
-
-[Install]
-WantedBy=multi-user.target

--- a/builder/files/lib/systemd/system/multi-user.target.wants/hypriot-resize-rootdisk.service
+++ b/builder/files/lib/systemd/system/multi-user.target.wants/hypriot-resize-rootdisk.service
@@ -1,1 +1,0 @@
-../hypriot-resize-rootdisk.service


### PR DESCRIPTION
**Only merge this PR when the os-rootfs is tagged with version 0.6 and the firstboot service is included!**
https://github.com/hypriot/os-rootfs/pull/7

This PR refactores the resize-root disk script to work with the firstboot service from the os-rootfs.
