### PR TITLE
Update rootfs v0.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ services:
   - docker
 language: bash
 script:
-  - make sd-image
+  - make shellcheck
+  - VERSION=${TRAVIS_TAG} make sd-image
 deploy:
   provider: releases
   api_key:
     secure: ZxbGrH2fjRBSFrCy3Q7kqOBZs/qeZ8QYXz3ZrbGBaoZlZuz9lZbrpBxwcaUbruyKvxx/J7iNeVBuSobz36K+qWQCe5OxOKkg14KzY0EOE6dLeIXWkTYX2ywYGgvlpzEhooly5KC6eJu5i3jyWjpUCBYOndZrAj4Zokx5v8hBQoLwf0LZB/KRQx7YAuz3f8jOkI881e+ic2rV+SNGPbocyNpcUZEBxeH2tsM+tBui7dThtSXzdc4QsJXnrsMrd+UAlrWqG+DTM+f+o9MWQbIOvY28pwHg2cdaIpd6+Y8tt1v+oT1nWThsaKQRYrk8wzi3SjoHTanaVuBa9jGaW4zzzl7zjGn385WN5FCwPoO3FTi+xOOzpWwucASXjs5LtQkgYfObk4Eo0LRdrjpfQZTlIzmoXElYSWWhhvQQh1gpagG/mCHGv/Vk09DDNHExk+U3KCR7BZISHiJ5F8Km3/1Gm27ewsO5cA8aGL6C6AwzynB7hkQgGvbnYr8MoeI2cfxKAKE1cH3zebdimas1gs/zsTDFIjrmu4bruZYf5V/I4MGsG3B/pwWsdWmRKRdOpylNNM/R791w3Ln/36oDqwQhHj5v7tlrNOqDa6hNg9YuKpOOBZMMHElxmqID0SepJzOZPv2EjFVOV5p7cpPL8z5NTy6mL9ZXpw4pj5s/6UjYzmk=
-  file: 
-    - sd-card-odroid-c1.img.zip
+  file:
+    - sd-card-odroid-c1-${TRAVIS_TAG}.img.zip
   on:
     tags: true
     repo: hypriot/image-builder-odroid-c1

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     awscli \
     ruby \
     ruby-dev \
+    shellcheck \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     kpartx \
     lvm2 \
     dosfstools \
+    zip \
+    unzip \
     pigz \
     awscli \
     ruby \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,31 @@ shell: build
 testshell: build
 	docker run -ti --privileged -v $(shell pwd)/builder:/builder -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-c1 bash
 
+test:
+	VERSION=dirty docker run --rm -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e VERSION image-builder-odroid-c1 bash -c "unzip /workspace/sd-card-odroid-c1-dirty.img.zip && rspec --format documentation --color /workspace/builder/test/*_spec.rb"
+
+shellcheck: build
+	VERSION=dirty docker run --rm -ti -v $(shell pwd):/workspace image-builder-odroid-c1 bash -c 'shellcheck /workspace/builder/*.sh /workspace/builder/files/etc/firstboot.d/*'
+
+vagrant:
+	vagrant up
+
+docker-machine: vagrant
+	docker-machine create -d generic \
+	  --generic-ssh-user $(shell vagrant ssh-config | grep ' User ' | cut -d ' ' -f 4) \
+	  --generic-ssh-key $(shell vagrant ssh-config | grep IdentityFile | cut -d ' ' -f 4) \
+	  --generic-ip-address $(shell vagrant ssh-config | grep HostName | cut -d ' ' -f 4) \
+	  --generic-ssh-port $(shell vagrant ssh-config | grep Port | cut -d ' ' -f 4) \
+	  image-builder-odroid-c1
+
+test-integration: test-integration-image test-integration-docker
+
+test-integration-image:
+	docker run --rm -ti -v $(shell pwd)/builder/test-integration:/serverspec:ro -e BOARD uzyexe/serverspec:2.24.3 bash -c "rspec --format documentation --color spec/hypriotos-image"
+
+test-integration-docker:
+	docker run --rm -ti -v $(shell pwd)/builder/test-integration:/serverspec:ro -e BOARD uzyexe/serverspec:2.24.3 bash -c "rspec --format documentation --color spec/hypriotos-docker"
+
 tag:
 	git tag ${TAG}
 	git push origin ${TAG}

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ build:
 	docker build -t image-builder-odroid-c1 .
 
 sd-image: build
-	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-c1
+	docker run --rm --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e VERSION image-builder-odroid-c1
 
 shell: build
-	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-c1 bash
+	docker run -ti --privileged -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules -e VERSION image-builder-odroid-c1 bash
 
 testshell: build
 	docker run -ti --privileged -v $(shell pwd)/builder:/builder -v $(shell pwd):/workspace -v /boot:/boot -v /lib/modules:/lib/modules image-builder-odroid-c1 bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "boxcutter/ubuntu1404"
 
-  config.vm.network "forwarded_port", guest: 2376, host: 2376
+  config.vm.network "forwarded_port", guest: 2376, host: 2376, auto_correct: true
   config.vm.synced_folder ".", "#{`pwd`.chomp}"
 
   config.vm.provider "vmware_fusion" do |v|

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -8,11 +8,6 @@ fi
 
 ### setting up some important variables to control the build process
 
-# device specific settings
-IMAGE_NAME="sd-card-odroid-c1.img"
-IMAGE_ROOTFS_PATH="/image-rootfs.tar.gz"
-QEMU_ARCH="arm"
-
 # where to store our created sd-image file
 BUILD_RESULT_PATH="/workspace"
 BUILD_PATH="/build"
@@ -24,6 +19,17 @@ ROOTFS_TAR_PATH="$BUILD_RESULT_PATH/$ROOTFS_TAR"
 
 # size of root and boot partion
 ROOT_PARTITION_SIZE="800M"
+
+# device specific settings
+IMAGE_VERSION=${VERSION:="dirty"}
+IMAGE_NAME="sd-card-odroid-c1-${IMAGE_VERSION}.img"
+IMAGE_ROOTFS_PATH="/image-rootfs.tar.gz"
+QEMU_ARCH="arm"
+
+# specific versions of kernel/firmware and docker tools
+export DOCKER_ENGINE_VERSION="1.9.1-1"
+export DOCKER_COMPOSE_VERSION="1.5.2-80"
+export DOCKER_MACHINE_VERSION="0.4.1-72"
 
 # create build directory for assembling our image filesystem
 rm -rf $BUILD_PATH
@@ -112,4 +118,4 @@ umask 0000
 pigz --zip -c $IMAGE_NAME > $BUILD_RESULT_PATH/$IMAGE_NAME.zip
 
 # test sd-image that we have built
-rspec --format documentation --color /builder/test
+VERSION=${IMAGE_VERSION} rspec --format documentation --color /builder/test

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -18,9 +18,9 @@ BUILD_RESULT_PATH="/workspace"
 BUILD_PATH="/build"
 
 # where to store our base file system
-ROOTFS_TAR="rootfs-armhf.tar.gz"
+ROOTFS_TAR_VERSION="v0.7.0"
+ROOTFS_TAR="rootfs-armhf-${ROOTFS_TAR_VERSION}.tar.gz"
 ROOTFS_TAR_PATH="$BUILD_RESULT_PATH/$ROOTFS_TAR"
-ROOTFS_TAR_VERSION="v0.6.1"
 
 # size of root and boot partion
 ROOT_PARTITION_SIZE="800M"

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -109,13 +109,13 @@ copy-file-to-device /boot/u-boot.bin /dev/sda destoffset:32768 sparse:true
 EOF
 
 # log image partioning
-fdisk -l /$IMAGE_NAME
+fdisk -l "/$IMAGE_NAME"
 
 # ensure that the travis-ci user can access the sd-card image file
 umask 0000
 
 # compress image
-pigz --zip -c $IMAGE_NAME > $BUILD_RESULT_PATH/$IMAGE_NAME.zip
+pigz --zip -c "$IMAGE_NAME" > "$BUILD_RESULT_PATH/$IMAGE_NAME.zip"
 
 # test sd-image that we have built
 VERSION=${IMAGE_VERSION} rspec --format documentation --color /builder/test

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -24,9 +24,9 @@ apt-get update
 
 # install Hypriot packages for using Docker
 apt-get install -y \
-  docker-hypriot \
-  docker-compose \
-  docker-machine
+  "docker-hypriot=${DOCKER_ENGINE_VERSION}" \
+  "docker-compose=${DOCKER_COMPOSE_VERSION}" \
+  "docker-machine=${DOCKER_MACHINE_VERSION}"
 
 #FIXME: should be handled in .deb package
 # setup Docker default configuration for ODROID C1

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -35,8 +35,8 @@ rm -f /etc/default/docker
 # --get upstream config
 wget -q -O /etc/default/docker https://github.com/docker/docker/raw/master/contrib/init/sysvinit-debian/docker.default
 # --enable aufs by default
-sed -i '/#DOCKER_OPTS/a \
-DOCKER_OPTS="--storage-driver=aufs -D"' /etc/default/docker
+sed -i "/#DOCKER_OPTS/a \
+DOCKER_OPTS=\"--storage-driver=aufs -D\"" /etc/default/docker
 
 #FIXME: should be handled in .deb package
 # enable Docker systemd service

--- a/builder/files/etc/firstboot.d/10-resize-rootdisk
+++ b/builder/files/etc/firstboot.d/10-resize-rootdisk
@@ -1,8 +1,11 @@
+#!/bin/bash
+set -ex
+
 # sd card device name for ODROID C1/C1+
 SDCARD_DEVICE="/dev/mmcblk0"
 
 # install parted, if its not there
-if [ -z $(which parted) ]; then
+if [ -z "$(which parted)" ]; then
   apt-get update
   apt-get install -y parted
 fi
@@ -12,15 +15,15 @@ df -h
 
 # get partition number
 PART_NUM=$(parted $SDCARD_DEVICE -ms unit s p | tail -n 1 | cut -f 1 -d:)
-echo $PART_NUM
+echo "$PART_NUM"
 
 # get partition start sector
-PART_START=$(parted $SDCARD_DEVICE -ms unit s p | grep ^$PART_NUM | cut -f 2 -d:)
-echo $PART_START
+PART_START=$(parted $SDCARD_DEVICE -ms unit s p | grep "^$PART_NUM" | cut -f 2 -d:)
+echo "$PART_START"
 
 # remove trailing "s"
 PART_START=${PART_START::-1}
-echo $PART_START
+echo "$PART_START"
 
 # change partition table for resizing to maximum
 set +e
@@ -40,7 +43,7 @@ set -e
 
 # apply online resizing
 partprobe
-/sbin/resize2fs ${SDCARD_DEVICE}p${PART_NUM}
+/sbin/resize2fs "${SDCARD_DEVICE}p${PART_NUM}"
 
 # show disk usage after changes
 df -h

--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -3,10 +3,7 @@ require 'spec_helper'
 describe file('/etc/os-release') do
   it { should be_file }
   it { should be_owned_by 'root' }
-  its(:content) { should match 'HYPRIOT_OS=' }
-  its(:content) { should match 'HYPRIOT_TAG=' }
-  its(:content) { should match 'HYPRIOT_DEVICE=' }
-
-  its(:content) { should match 'HypriotOS/armhf' }
-  its(:content) { should match 'ODROID C1/C1+' }
+  its(:content) { should match 'HYPRIOT_OS="HypriotOS/armhf"' }
+  its(:content) { should match 'HYPRIOT_TAG="v0.7.0"' }
+  its(:content) { should match 'HYPRIOT_DEVICE="ODROID C1/C1+"' }
 end

--- a/builder/test/image_spec.rb
+++ b/builder/test/image_spec.rb
@@ -1,21 +1,16 @@
-require 'serverspec'
-set :backend, :exec
+require_relative 'spec_helper'
 
 describe "SD-Card Image" do
-  let(:image_path) { return '/sd-card-odroid-c1.img' }
-
   it "exists" do
     image_file = file(image_path)
-
     expect(image_file).to exist
   end
 
   context "Partition table" do
-    let(:stdout) { command("guestfish add #{image_path} : run : list-filesystems").stdout }
+    let(:stdout) { run("list-filesystems").stdout }
 
     it "has one partition" do
       partitions = stdout.split(/\r?\n/)
-
       expect(partitions.size).to be 1
     end
 

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -1,12 +1,10 @@
-require 'serverspec'
-set :backend, :exec
+require_relative 'spec_helper'
 
 describe "Root filesystem" do
   let(:rootfs_path) { return '/build' }
 
   it "exists" do
     rootfs_dir = file(rootfs_path)
-
     expect(rootfs_dir).to exist
   end
 

--- a/builder/test/spec_helper.rb
+++ b/builder/test/spec_helper.rb
@@ -1,0 +1,14 @@
+require 'serverspec'
+set :backend, :exec
+
+def image_path
+  return "sd-card-odroid-c1-#{ENV['VERSION']}.img"
+end
+
+def run( cmd )
+  return command("guestfish add #{image_path} : run : #{cmd}")
+end
+
+def run_mounted( cmd )
+  return run("mount /dev/sda2 / : #{cmd}")
+end


### PR DESCRIPTION
Update to rootfs v0.7.0 which now has the version number in its filename.

Fixes #11 versioned rootfs
Fixes #13 shebang
Fixes #18 versioned sd image file
Adds shellcheck tests
