### PR TITLE
Upgrade versions for rootfs and Docker engine

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -28,7 +28,7 @@ QEMU_ARCH="arm"
 export HYPRIOT_IMAGE_VERSION
 
 # specific versions of kernel/firmware and docker tools
-export DOCKER_ENGINE_VERSION="1.10.0-1"
+export DOCKER_ENGINE_VERSION="1.10.1-1"
 export DOCKER_COMPOSE_VERSION="1.6.0-27"
 export DOCKER_MACHINE_VERSION="0.4.1-72"
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -13,7 +13,7 @@ BUILD_RESULT_PATH="/workspace"
 BUILD_PATH="/build"
 
 # where to store our base file system
-HYPRIOT_OS_VERSION="v0.7.1"
+HYPRIOT_OS_VERSION="v0.7.2"
 ROOTFS_TAR="rootfs-armhf-${HYPRIOT_OS_VERSION}.tar.gz"
 ROOTFS_TAR_PATH="$BUILD_RESULT_PATH/$ROOTFS_TAR"
 

--- a/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/release_spec.rb
@@ -4,7 +4,7 @@ describe file('/etc/os-release') do
   it { should be_file }
   it { should be_owned_by 'root' }
   its(:content) { should match 'HYPRIOT_OS="HypriotOS/armhf"' }
-  its(:content) { should match 'HYPRIOT_OS_VERSION="v0.7.1"' }
+  its(:content) { should match 'HYPRIOT_OS_VERSION="v0.7.2"' }
   its(:content) { should match 'HYPRIOT_DEVICE="ODROID C1/C1\+"' }
   its(:content) { should match 'HYPRIOT_IMAGE_VERSION=' }
 end

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe command('dpkg -l docker-hypriot') do
   its(:stdout) { should match /ii  docker-hypriot/ }
-  its(:stdout) { should match /1.10.0-1/ }
+  its(:stdout) { should match /1.10.1-1/ }
   its(:exit_status) { should eq 0 }
 end
 
@@ -47,13 +47,13 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 1.10.0, build/ }
+  its(:stdout) { should match /Docker version 1.10.1, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:      1.10.0. API version:  1.22/m }
-  its(:stdout) { should match /Server:. Version:      1.10.0. API version:  1.22/m }
+  its(:stdout) { should match /Client:. Version:      1.10.1. API version:  1.22/m }
+  its(:stdout) { should match /Server:. Version:      1.10.1. API version:  1.22/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -36,8 +36,8 @@ describe "Root filesystem" do
     expect(stdout).to contain('HYPRIOT_DEVICE="ODROID C1/C1')
   end
 
-  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.7.1\"'" do
-    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.7.1"$')
+  it "uses os-rootfs version 'HYPRIOT_OS_VERSION=\"v0.7.2\"'" do
+    expect(stdout).to contain('^HYPRIOT_OS_VERSION="v0.7.2"$')
   end
 
   if ENV.fetch('TRAVIS_TAG','') != ''


### PR DESCRIPTION
- Upgrade to Docker engine v1.10.1-1
- Upgrade to rootfs v0.7.2
