### PR TITLE
Fixed docker-machine installation.

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -50,7 +50,7 @@ apt-get -y install --no-install-recommends ${packages[*]}
 pip install docker-compose=="${DOCKER_COMPOSE_VERSION}"
 
 # install docker-machine
-curl -L "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-machine
+curl -L "https://github.com/docker/machine/releases/download/v${DOCKER_MACHINE_VERSION}/docker-machine-$(uname -s)-$(dpkg --print-architecture)" > /usr/local/bin/docker-machine
 chmod +x /usr/local/bin/docker-machine
 
 # install ODROID kernel

--- a/builder/test-integration/spec/hypriotos-image/base/packages_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/packages_spec.rb
@@ -51,7 +51,7 @@ end
 describe package('initramfs-tools') do
   it { should be_installed }
 end
-describe package('linux-image-c1') do
+describe package('linux-image-3.10.104-186') do
   it { should be_installed }
 end
 
@@ -60,11 +60,5 @@ describe package('device-init') do
   it { should be_installed }
 end
 describe package('docker-engine') do
-  it { should be_installed }
-end
-describe package('docker-compose') do
-  it { should be_installed }
-end
-describe package('docker-machine') do
   it { should be_installed }
 end

--- a/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe package('docker-compose') do
-  it { should be_installed }
-end
-
-describe command('dpkg -l docker-compose') do
   it { should_not be_installed }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe package('docker-machine') do
-  it { should be_installed }
-end
-
-describe command('dpkg -l docker-machine') do
   it { should_not be_installed }
 end
 


### PR DESCRIPTION
Unfortunately, ```uname -m``` doesn't evaluate to 'armhf' but to 'armv7l'. So it looks like the installation steps on the ```docker-machine``` release notes do not universally work.